### PR TITLE
[fix] tests for data feilds: file, line, name

### DIFF
--- a/lib/TapeToJUnit.js
+++ b/lib/TapeToJUnit.js
@@ -103,9 +103,18 @@ TapeToJUnit.prototype._parseCase = function(data)
   if (data.operator === 'error') {
     test.errors = 1;
   } else {
-    test.file = data.file.match(/(.*):\d+:\d+$/)[1];
-    test.line = data.line;
-    test.name = data.name;
+    
+    if (data.file) {
+      test.file = data.file.match(/(.*):\d+:\d+$/)[1];
+    }
+    
+    if (data.line) {
+      test.line = data.line;
+    }
+    
+    if (data.name) {
+      test.name = data.name;
+    }
 
     if (data.ok) {
       test.assertions = 1;


### PR DESCRIPTION
The reason for this change is primarily for a bug I found where if tape can't resolve the filename and line from the error stack, tape-junit will crash with `TypeError: Cannot call method 'match' of undefined`
