### PR TITLE
[tape] bump tape version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tape-junit",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Output JUnit XML from tape-driven tests.",
   "keywords": [
     "tap",
@@ -30,7 +30,7 @@
     "url": "git@github.com:bvalosek/tape-junit.git"
   },
   "peerDependencies": {
-    "tape": "^3.0.0"
+    "tape": "^4.0.0"
   },
   "dependencies": {
     "glob": "~3.2.9"


### PR DESCRIPTION
Fixes this problem

```
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package tape does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer tape-junit@0.4.0 wants tape@^3.0.0
```
